### PR TITLE
V0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release Notes
 
-## v0.2.1 (2025-06-12)
+## v0.2.1 (2025-06-14)
 - 🐛 Update LSP textwire to the latest version which will fix crashing LSP when you make a syntax error in your Textwire code
+- ✨ Autocomplete snippets that appear after you hit enter are now more complex. Instead of simple autocomple like `@if` you know get the full if statement and the cursor placed inside condition. It allows you to hit tab to move to the next place in a snippet
 
 ## v0.2.0 (2025-05-30)
 - ✨ Add autocompletion for loop object. Now if you type `loop.` inside of a loop, it will show available properties on the object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v0.2.1 (2025-06-12)
+- 🐛 Update LSP textwire to the latest version which will fix crashing LSP when you make a syntax error in your Textwire code
+
 ## v0.2.0 (2025-05-30)
 - ✨ Add autocompletion for loop object. Now if you type `loop.` inside of a loop, it will show available properties on the object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v0.2.1 (2025-06-14)
+## v0.3.0 (2025-06-14)
 - 🐛 Update LSP textwire to the latest version which will fix crashing LSP when you make a syntax error in your Textwire code
 - ✨ Autocomplete snippets that appear after you hit enter are now more complex. Instead of simple autocomple like `@if` you know get the full if statement and the cursor placed inside condition. It allows you to hit tab to move to the next place in a snippet
 

--- a/analysis/completion.go
+++ b/analysis/completion.go
@@ -40,9 +40,8 @@ func (s *State) Completion(id int, uri string, pos lsp.Position) (lsp.Completion
 		doc = removeTrailingChar(doc, pos.Line, pos.Character, '.')
 
 		isInsideLoop, errors := twLsp.IsInLoop(doc, uri, pos.Line, pos.Character)
-		if errors != nil && len(errors) > 0 {
+		if len(errors) > 0 {
 			logger.Error.Println(errors[0])
-			return lsp.CompletionResponse{}, err
 		}
 
 		if isInsideLoop {

--- a/analysis/completion.go
+++ b/analysis/completion.go
@@ -77,9 +77,10 @@ func (s *State) makeCompletions(completionItems []completions.Completion) []lsp.
 
 	for _, item := range completionItems {
 		items = append(items, lsp.CompletionItem{
-			Label:      item.Label,
-			FilterText: item.Insert,
-			InsertText: item.Insert,
+			Label:            item.Label,
+			FilterText:       item.InsertText,
+			InsertText:       item.InsertText,
+			InsertTextFormat: item.InsertTextFormat,
 			Documentation: lsp.MarkupContent{
 				Kind:  "markdown",
 				Value: item.Documentation,

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/textwire/lsp
 
 go 1.23.3
 
-require github.com/textwire/textwire/v2 v2.5.9
+require github.com/textwire/textwire/v2 v2.6.2

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/textwire/lsp
 
 go 1.23.3
 
-require github.com/textwire/textwire/v2 v2.6.2
+require github.com/textwire/textwire/v2 v2.6.6

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,5 @@ github.com/textwire/textwire/v2 v2.5.9 h1:ZK0v/neW2H5EPv5oPf1vmrPK+0JthrQSbs98V0
 github.com/textwire/textwire/v2 v2.5.9/go.mod h1:V0J75qH85DM8OAICWewhXyyXPXVAZYwhhiORGrWgj5I=
 github.com/textwire/textwire/v2 v2.6.2 h1:nqRxNWaeHwsqCzsmCsO4yqJMWDLdYliUVlCHeYfyS1c=
 github.com/textwire/textwire/v2 v2.6.2/go.mod h1:V0J75qH85DM8OAICWewhXyyXPXVAZYwhhiORGrWgj5I=
+github.com/textwire/textwire/v2 v2.6.6 h1:XYa6RWUcmodmHtVY9oMRb56DP0w9j80BeibcgSKxuac=
+github.com/textwire/textwire/v2 v2.6.6/go.mod h1:V0J75qH85DM8OAICWewhXyyXPXVAZYwhhiORGrWgj5I=

--- a/go.sum
+++ b/go.sum
@@ -16,3 +16,5 @@ github.com/textwire/textwire/v2 v2.5.8 h1:PMPookvEf1eRlUHuTlhoZdOFrH5yviWu5hYTqB
 github.com/textwire/textwire/v2 v2.5.8/go.mod h1:V0J75qH85DM8OAICWewhXyyXPXVAZYwhhiORGrWgj5I=
 github.com/textwire/textwire/v2 v2.5.9 h1:ZK0v/neW2H5EPv5oPf1vmrPK+0JthrQSbs98V0nZyp4=
 github.com/textwire/textwire/v2 v2.5.9/go.mod h1:V0J75qH85DM8OAICWewhXyyXPXVAZYwhhiORGrWgj5I=
+github.com/textwire/textwire/v2 v2.6.2 h1:nqRxNWaeHwsqCzsmCsO4yqJMWDLdYliUVlCHeYfyS1c=
+github.com/textwire/textwire/v2 v2.6.2/go.mod h1:V0J75qH85DM8OAICWewhXyyXPXVAZYwhhiORGrWgj5I=

--- a/lsp/textdocument_completion.go
+++ b/lsp/textdocument_completion.go
@@ -88,6 +88,13 @@ type CompletionItem struct {
 
 	// Documentation is a human-readable string that represents a doc-comment.
 	Documentation MarkupContent `json:"documentation,omitempty"`
+
+	// InsertTextFormat defines whether the insert text in a completion
+	// item should be interpreted as plain text or a snippet.
+	// 1 stands for text format
+	// 2 stands for snippet where you can include `${3:foo}` and just `$1`
+	// special symbols to tell where to place the cursor
+	InsertTextFormat int `json:"insertTextFormat"`
 }
 
 type MarkupContent struct {

--- a/main.go
+++ b/main.go
@@ -76,7 +76,6 @@ func handleMessage(writer io.Writer, state analysis.State, method string, conten
 		resp, err := state.Hover(req.ID, req.Params.TextDocument.URI, req.Params.Position)
 		if err != nil {
 			logger.Error.Printf("textDocument/hover error: %s", err)
-			return
 		}
 
 		writeResponse(writer, resp)
@@ -90,7 +89,6 @@ func handleMessage(writer io.Writer, state analysis.State, method string, conten
 		resp, err := state.Completion(req.ID, req.Params.TextDocument.URI, req.Params.Position)
 		if err != nil {
 			logger.Error.Printf("textDocument/completion error: %s", err)
-			return
 		}
 
 		writeResponse(writer, resp)


### PR DESCRIPTION
- 🐛 Update LSP textwire to the latest version, which will fix crashing LSP when you make a syntax error in your Textwire code
- ✨ Autocomplete snippets that appear after you hit enter are now more complex. Instead of simple autocomplete like `@if` you know, get the full if statement and the cursor placed inside the condition. It allows you to hit tab to move to the next place in a snippet.